### PR TITLE
Bump enum-iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-enum-iterator = "0.6.*"
+enum-iterator = "0.7.*"
 num-traits = "0.2.*"


### PR DESCRIPTION
Recently a new version of [enum-iterator](https://github.com/stephaneyfx/enum-iterator) is released. See the changes: [0.6.0...0.7.0](https://github.com/stephaneyfx/enum-iterator/compare/0.6.0...0.7.0)

This PR bumps the `enum-iterator` dependency to work with the latest version. Thus, prevents the missing implementation error in the following case:

```toml
enum-unitary = "0.4.2"
enum-iterator = "0.7.0"
```

it does not compile:

```
error[E0277]: the trait bound `app::Block: enum_unitary::IntoEnumIterator` is not satisfied
  --> src/app.rs:57:1
   |
57 | / enum_unitary! {
58 | |     #[derive(Copy, Debug, PartialEq)]
59 | |     pub enum Block {
60 | |         UserInput,
...  |
64 | |     }
65 | | }
   | |_^ the trait `enum_unitary::IntoEnumIterator` is not implemented for `app::Block`
   |
  ::: /home/orhun/.cargo/registry/src/github.com-1ecc6299db9ec823/enum-unitary-0.4.2/src/lib.rs:25:45
   |
25 |     + Bounded + ToPrimitive + FromPrimitive + IntoEnumIterator
   |                                               ---------------- required by this bound in `EnumUnitary`
   |
   = note: this error originates in the macro `$crate::enum_unitary` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Also it would be nice to get a new version of `enum-unitary` along with these changes. (preferably `0.4.3`)

Thanks
